### PR TITLE
feat: add daily GitHub Action to auto-verify and update docker-install SHA256

### DIFF
--- a/.github/workflows/daily-docker-install-hash.yml
+++ b/.github/workflows/daily-docker-install-hash.yml
@@ -1,0 +1,30 @@
+name: Daily Docker Installer Hash Verify
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  verify-docker-install-hash:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Verify docker-install hash and update script
+        run: ./scripts/update-docker-install-hash.sh
+
+      - name: Commit changes if hash updated
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update docker install hash'
+          file_pattern: install-ss-docker.sh

--- a/README.en.md
+++ b/README.en.md
@@ -99,8 +99,8 @@ ss://base64(cipher:password@server_ip:port)#label
 curl -fsSL "https://raw.githubusercontent.com/docker/docker-install/<VERSION>/install.sh" -o /tmp/docker-install.sh
 sha256sum /tmp/docker-install.sh
 ```
-3. Update `DOCKER_INSTALL_VERSION`, `DOCKER_INSTALL_URL`, and `EXPECTED_DOCKER_INSTALL_SHA256` in `install-ss-docker.sh`.
-4. Re-run download + verification before merging.
+3. This repo includes `scripts/update-docker-install-hash.sh`, and `.github/workflows/daily-docker-install-hash.yml` runs it once per day automatically.
+4. If the hash changes, the workflow auto-updates `install-ss-docker.sh` and commits the change; you can also run the script locally.
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ ss://base64(加密算法:密码@服务器IP:端口)#服务器标识
 curl -fsSL "https://raw.githubusercontent.com/docker/docker-install/<VERSION>/install.sh" -o /tmp/docker-install.sh
 sha256sum /tmp/docker-install.sh
 ```
-3. 同步更新 `install-ss-docker.sh` 中的 `DOCKER_INSTALL_VERSION`、`DOCKER_INSTALL_URL`、`EXPECTED_DOCKER_INSTALL_SHA256`。
-4. 提交前重新执行下载+校验，确认脚本可正常安装。
+3. 仓库内已提供自动化脚本 `scripts/update-docker-install-hash.sh`，并由 GitHub Action `.github/workflows/daily-docker-install-hash.yml` 每天自动执行一次。
+4. 若哈希发生变化，Action 会自动更新 `install-ss-docker.sh` 并提交代码；也可手动执行该脚本进行本地更新。
 
 ## 客户端支持
 

--- a/scripts/update-docker-install-hash.sh
+++ b/scripts/update-docker-install-hash.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_FILE="install-ss-docker.sh"
+DOCKER_INSTALL_REPO="docker/docker-install"
+URL_TEMPLATE='https://raw.githubusercontent.com/docker/docker-install/${DOCKER_INSTALL_VERSION}/install.sh'
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+  echo "error: $TARGET_FILE not found" >&2
+  exit 1
+fi
+
+latest_commit=$(curl -fsSL "https://api.github.com/repos/${DOCKER_INSTALL_REPO}/commits/master" | jq -r '.sha')
+if [[ -z "$latest_commit" || "$latest_commit" == "null" ]]; then
+  echo "error: unable to resolve latest commit from ${DOCKER_INSTALL_REPO}" >&2
+  exit 1
+fi
+
+latest_url="https://raw.githubusercontent.com/${DOCKER_INSTALL_REPO}/${latest_commit}/install.sh"
+latest_sha256=$(curl -fsSL "$latest_url" | sha256sum | awk '{print $1}')
+if [[ -z "$latest_sha256" ]]; then
+  echo "error: unable to calculate SHA256 for ${latest_url}" >&2
+  exit 1
+fi
+
+python3 - "$TARGET_FILE" "$latest_commit" "$latest_sha256" "$URL_TEMPLATE" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+version, sha256, url_template = sys.argv[2:]
+text = path.read_text(encoding="utf-8")
+
+updated = re.sub(r'^DOCKER_INSTALL_VERSION="[^"]+"$', f'DOCKER_INSTALL_VERSION="{version}"', text, count=1, flags=re.M)
+updated = re.sub(r'^DOCKER_INSTALL_URL="[^"]+"$', f'DOCKER_INSTALL_URL="{url_template}"', updated, count=1, flags=re.M)
+updated = re.sub(r'^EXPECTED_DOCKER_INSTALL_SHA256="[^"]+"$', f'EXPECTED_DOCKER_INSTALL_SHA256="{sha256}"', updated, count=1, flags=re.M)
+
+if updated != text:
+    path.write_text(updated, encoding="utf-8")
+    print(f"updated {path}")
+else:
+    print(f"no changes in {path}")
+PY
+
+echo "Resolved docker-install commit: ${latest_commit}"
+echo "Resolved docker-install sha256: ${latest_sha256}"


### PR DESCRIPTION
### Motivation
- Automate daily verification of the upstream `docker-install` installer and keep the pinned installer URL/commit and SHA256 in `install-ss-docker.sh` up to date to avoid manual maintenance and reduce the risk of using an unexpected installer.

### Description
- Add `scripts/update-docker-install-hash.sh` which resolves the latest `docker/docker-install` commit, downloads `install.sh`, calculates its SHA256, and updates `DOCKER_INSTALL_VERSION`, `DOCKER_INSTALL_URL`, and `EXPECTED_DOCKER_INSTALL_SHA256` in `install-ss-docker.sh` when needed.
- Add `.github/workflows/daily-docker-install-hash.yml` which runs the verification script once per day (and on-demand) and commits changes to `install-ss-docker.sh` if the hash or pinned commit changed.
- Update `README.md` and `README.en.md` to document the automated daily verification workflow and the presence of the update script.
- Minor update to `install-ss-docker.sh` (URL became explicitly pinned) to match values produced/managed by the automation.

### Testing
- Executed `./scripts/update-docker-install-hash.sh`, which completed successfully and printed the resolved commit and SHA256.
- Performed syntax checks with `bash -n scripts/update-docker-install-hash.sh` and `bash -n install-ss-docker.sh`, both of which returned no syntax errors.
- Verified README patches were applied by updating the files and ensuring the new workflow and script are referenced correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698598f0629c8329804ce64c8a02348f)